### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,83 @@
+name: 🏗️ Build and 🚀 Publish release
+
+on:
+  push:
+    tags: ['*']
+
+jobs:
+  create-release:
+    name: Create release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Create release ${{ github.ref }} as a draft
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release create "${{ github.ref }}" --draft --generate-notes
+
+  matrix:
+    name: Generate matrix
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install required packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yqq jq
+    - name: Generate matrix
+      id: matrix
+      run: |
+        . build-config
+        echo "::echo::on"
+        echo "::set-output name=distros::$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETABLE_DISTROS[@]}")"
+        echo "::set-output name=versions::$(jq --compact-output --null-input '$ARGS.positional' --args -- "${TARGETABLE_VERSIONS[@]}")"
+
+        EXCLUDE=""
+        for DISTRO in "${TARGETABLE_DISTROS[@]}"; do
+          for OBS_VER in "${TARGETABLE_VERSIONS[@]}"; do
+            ./build-validate.sh "${DISTRO}" "${OBS_VER}" && continue
+            EXCLUDE="${EXCLUDE:+$EXCLUDE,}{\"distro\": \"${DISTRO}\", \"version\": \"${OBS_VER}\"}"
+          done
+        done
+        echo "::set-output name=exclude::[${EXCLUDE}]"
+    outputs:
+      distros: ${{ steps.matrix.outputs.distros }}
+      versions: ${{ steps.matrix.outputs.versions }}
+      exclude: ${{ steps.matrix.outputs.exclude }}
+
+  build:
+    name: Build all packages
+    runs-on: ubuntu-latest
+    needs: [create-release, matrix]
+    strategy:
+      matrix:
+        distro: ${{ fromJson(needs.matrix.outputs.distros) }}
+        version: ${{ fromJson(needs.matrix.outputs.versions) }}
+        exclude: ${{ fromJson(needs.matrix.outputs.exclude) }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build OBS ${{ matrix.version }} for ${{ matrix.distro }}
+      run: sudo env OVERRIDE_BUILDS_DIR="$PWD" ./build-auto.sh "${{ matrix.distro }}" "${{ matrix.version }}"
+    - name: Upload OBS ${{ matrix.version }} for ${{ matrix.distro }} artefacts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        for artefact in "artefacts/obs-portable-${{ matrix.version }}"*; do
+          gh release upload "${{ github.ref }}" "${artefact}" --clobber
+        done
+
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs: [create-release, build]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Publish release ${{ github.ref }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if [ "$(gh release view "${{ github.ref }}" --json assets --template '{{len .assets}}')" -lt 0 ]; then
+          exit 1
+        fi
+        gh release edit "${{ github.ref }}" --draft=false

--- a/build-auto.sh
+++ b/build-auto.sh
@@ -10,19 +10,25 @@ if [ -z "${1}" ] || [ -z "${2}" ]; then
     exit 1
 fi
 
-case "${1}" in
-    focal|jammy|kinetic) DISTROS="${1}";;
-    all) DISTROS="kinetic jammy focal";;
-    *) echo "ERROR! Unknown Ubuntu release: ${1}"
-      exit 1;;
-esac
+. "$(dirname "$0")/build-config"
 
-case "${2}" in
-    26|27|28)  OBS_VERS="${2}";;
-    all) OBS_VERS="28 27 26";;
-    *) echo "ERROR! Unsupported OBS Studio version: ${2}"
-       exit 1;;
-esac
+if [ "${1}" = "all" ]; then
+    DISTROS="${TARGETABLE_DISTROS[@]}"
+elif [[ "${TARGETABLE_DISTROS[@]}" =~ "${1}" ]]; then
+    DISTROS="${1}"
+else
+    echo "ERROR! Unknown Ubuntu release: ${1}"
+    exit 1
+fi
+
+if [ "${2}" = "all" ]; then
+    OBS_VERS="${TARGETABLE_VERSIONS[@]}"
+elif [[ "${TARGETABLE_VERSIONS[@]}" =~ "${2}" ]]; then
+    OBS_VERS="${2}"
+else
+    echo "ERROR! Unsupported OBS Studio version: ${2}"
+    exit 1
+fi
 
 for DISTRO in ${DISTROS}; do
     for OBS_VER in ${OBS_VERS}; do

--- a/build-auto.sh
+++ b/build-auto.sh
@@ -32,10 +32,7 @@ fi
 
 for DISTRO in ${DISTROS}; do
     for OBS_VER in ${OBS_VERS}; do
-        if [ "${DISTRO}" == "kinetic" ] && [ "${OBS_VER}" -le 27 ]; then
-            # Do not try and build old OBS versions on Ubuntu 22.10
-            continue
-        fi
+        ./build-validate.sh "${DISTRO}" "${OBS_VER}" || continue
         ./build-trash.sh "${DISTRO}"
         ./build-bootstrap.sh "${DISTRO}"
         ./build-enter.sh "${DISTRO}" "/root/obs-portable.sh ${OBS_VER}"

--- a/build-bootstrap.sh
+++ b/build-bootstrap.sh
@@ -12,13 +12,16 @@ if [ -z "${1}" ]; then
     exit 1
 fi
 
+. "$(dirname "$0")/build-config"
+
 DISTRO="${1}"
-case "${DISTRO}" in
-    focal|jammy|kinetic) true;;
-    *) echo "ERROR! Unknown version: ${DISTRO}"
-       exit 1
-      ;;
-esac
+if [[ "${TARGETABLE_DISTROS[@]}" =~ "${DISTRO}" ]]; then
+    true
+else
+    echo "ERROR! Unknown version: ${DISTRO}"
+    exit 1
+fi
+
 R="${SUDO_HOME}/Builds/obs-builder-${DISTRO}"
 
 if [ ! -d "${R}" ]; then

--- a/build-bootstrap.sh
+++ b/build-bootstrap.sh
@@ -4,8 +4,10 @@ if [ -z "${SUDO_USER}" ]; then
     echo "ERROR! You must use sudo to run this script: sudo ./$(basename "${0}")"
     exit 1
 else
-    SUDO_HOME=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
+    BUILDS_DIR=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
 fi
+
+BUILDS_DIR="${OVERRIDE_BUILDS_DIR:-$BUILDS_DIR}"
 
 if [ -z "${1}" ]; then
     echo "Usage: $(basename "${0}") <codename>"
@@ -22,7 +24,7 @@ else
     exit 1
 fi
 
-R="${SUDO_HOME}/Builds/obs-builder-${DISTRO}"
+R="${BUILDS_DIR}/Builds/obs-builder-${DISTRO}"
 
 if [ ! -d "${R}" ]; then
     apt-get -y install debootstrap systemd-container debian-archive-keyring ubuntu-keyring

--- a/build-config
+++ b/build-config
@@ -1,0 +1,2 @@
+TARGETABLE_DISTROS=("kinetic" "jammy" "focal")
+TARGETABLE_VERSIONS=("28" "27" "26")

--- a/build-enter.sh
+++ b/build-enter.sh
@@ -4,8 +4,10 @@ if [ -z "${SUDO_USER}" ]; then
     echo "ERROR! You must use sudo to run this script: sudo ./$(basename "${0}")"
     exit 1
 else
-    SUDO_HOME=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
+    BUILDS_DIR="$(getent passwd "${SUDO_USER}" | cut -d: -f6)"
 fi
+
+BUILDS_DIR="${OVERRIDE_BUILDS_DIR:-$BUILDS_DIR}"
 
 if [ -z "${1}" ]; then
     echo "Usage: $(basename "${0}") <codename>"
@@ -28,7 +30,7 @@ else
     exit 1
 fi
 
-R="${SUDO_HOME}/Builds/obs-builder-${DISTRO}"
+R="${BUILDS_DIR}/Builds/obs-builder-${DISTRO}"
 APT_CACHE_IP=$(ip route get 1.1.1.1 | head -n 1 | cut -d' ' -f 7)
 
 if pidof -q apt-cacher-ng && [ -d "${R}/etc/apt/apt.conf.d" ]; then

--- a/build-enter.sh
+++ b/build-enter.sh
@@ -19,12 +19,14 @@ else
     CMD="/bin/bash"
 fi
 
-case "${DISTRO}" in
-    focal|jammy|kinetic) true;;
-    *) echo "ERROR! Unknown version: ${DISTRO}"
-       exit 1
-       ;;
-esac
+. "$(dirname "$0")/build-config"
+
+if [[ "${TARGETABLE_DISTROS[@]}" =~ "${DISTRO}" ]]; then
+    true
+else
+    echo "ERROR! Unknown version: ${DISTRO}"
+    exit 1
+fi
 
 R="${SUDO_HOME}/Builds/obs-builder-${DISTRO}"
 APT_CACHE_IP=$(ip route get 1.1.1.1 | head -n 1 | cut -d' ' -f 7)

--- a/build-get-artefacts.sh
+++ b/build-get-artefacts.sh
@@ -4,8 +4,10 @@ if [ -z "${SUDO_USER}" ]; then
     echo "ERROR! You must use sudo to run this script: sudo ./$(basename "${0}")"
     exit 1
 else
-    SUDO_HOME=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
+    BUILDS_DIR="$(getent passwd "${SUDO_USER}" | cut -d: -f6)"
 fi
+
+BUILDS_DIR="${OVERRIDE_BUILDS_DIR:-$BUILDS_DIR}"
 
 if [ -z "${1}" ] || [ -z "${2}" ]; then
     echo "Usage: $(basename "${0}") <codename> <obs_ver>"
@@ -25,8 +27,8 @@ esac
 
 case "${OBS_VER}" in
     26|27|28)
-        if [ -d "${SUDO_HOME}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_VER}" ]; then
-            cp -v "${SUDO_HOME}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_VER}"/obs-portable-${OBS_VER}*-ubuntu-${DISTRO_VER}.* artefacts/
+        if [ -d "${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_VER}" ]; then
+            cp -v "${BUILDS_DIR}/Builds/obs-builder-${DISTRO}/root/obs-${OBS_VER}"/obs-portable-${OBS_VER}*-ubuntu-${DISTRO_VER}.* artefacts/
             chown "${SUDO_USER}":"${SUDO_USER}" "artefacts/obs-portable-${OBS_VER}"*-ubuntu-${DISTRO_VER}.*
         fi;;
     *) echo "ERROR! Unsupported OBS Studio version: ${OBS_VER}"

--- a/build-trash.sh
+++ b/build-trash.sh
@@ -4,8 +4,10 @@ if [ -z "${SUDO_USER}" ]; then
     echo "ERROR! You must use sudo to run this script: sudo ./$(basename "${0}")"
     exit 1
 else
-    SUDO_HOME=$(getent passwd "${SUDO_USER}" | cut -d: -f6)
+    BUILDS_DIR="$(getent passwd "${SUDO_USER}" | cut -d: -f6)"
 fi
+
+BUILDS_DIR="${OVERRIDE_BUILDS_DIR:-$BUILDS_DIR}"
 
 if [ -z "${1}" ]; then
     echo "Usage: $(basename "${0}") <codename>"
@@ -22,7 +24,7 @@ else
     exit 1
 fi
 
-R="${SUDO_HOME}/Builds/obs-builder-${DISTRO}"
+R="${BUILDS_DIR}/Builds/obs-builder-${DISTRO}"
 if [ -d "${R}" ]; then
     rm -rf "${R}"
 fi

--- a/build-trash.sh
+++ b/build-trash.sh
@@ -12,13 +12,15 @@ if [ -z "${1}" ]; then
     exit 1
 fi
 
+. "$(dirname "$0")/build-config"
+
 DISTRO="${1}"
-case "${DISTRO}" in
-    focal|jammy|kinetic) true;;
-    *) echo "ERROR! Unknown version: ${DISTRO}"
-      exit 1
-      ;;
-esac
+if [[ "${TARGETABLE_DISTROS[@]}" =~ "${DISTRO}" ]]; then
+    true
+else
+    echo "ERROR! Unknown version: ${DISTRO}"
+    exit 1
+fi
 
 R="${SUDO_HOME}/Builds/obs-builder-${DISTRO}"
 if [ -d "${R}" ]; then

--- a/build-validate.sh
+++ b/build-validate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ "${1}" = "kinetic" ] && [ "${2}" -le 27 ]; then
+    # Do not try and build old OBS versions on Ubuntu 22.10
+    exit 1
+fi
+
+# Build is allowed to proceed
+exit 0


### PR DESCRIPTION
Whenever a tag is pushed to the repository GitHub Actions will build
the project for all supported distros and OBS versions and create a
GitHub Release with automatically generated release notes for the
tag.

Includes:
- Make obs versions / distros declarative
- Allow overriding the build directory
- Add build-validate.sh to help with GitHub Actions