### PR TITLE
Fix passing of secrets around in GitHub Actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -68,15 +68,7 @@ jobs:
         YOUTUBE_SECRET: ${{ secrets.YOUTUBE_SECRET }}
         YOUTUBE_SECRET_HASH: ${{ secrets.YOUTUBE_SECRET_HASH }}
       run: >
-        sudo env OVERRIDE_BUILDS_DIR="$PWD"
-        TWITCH_CLIENT_ID="'"${TWITCH_CLIENTID}"'"
-        TWITCH_HASH="'"${TWITCH_HASH}"'"
-        RESTREAM_CLIENTID="'"${RESTREAM_CLIENTID}"'"
-        RESTREAM_HASH="'"${RESTREAM_HASH}"'"
-        YOUTUBE_CLIENTID="'"${YOUTUBE_CLIENTID}"'"
-        YOUTUBE_CLIENTID_HASH="'"${YOUTUBE_CLIENTID_HASH}"'"
-        YOUTUBE_SECRET="'"${YOUTUBE_SECRET}"'"
-        YOUTUBE_SECRET_HASH="'"${YOUTUBE_SECRET_HASH}"'"
+        sudo --preserve-env
         ./build-auto.sh "${{ matrix.distro }}" "${{ matrix.version }}"
     - name: Upload OBS ${{ matrix.version }} for ${{ matrix.distro }} artefacts
       env:

--- a/build-enter.sh
+++ b/build-enter.sh
@@ -45,6 +45,14 @@ systemd-nspawn \
     --hostname="${DISTRO}" \
     --machine="${DISTRO}" \
     --resolv-conf=off \
+    --setenv=TWITCH_CLIENT_ID \
+    --setenv=TWITCH_HASH \
+    --setenv=RESTREAM_CLIENTID \
+    --setenv=RESTREAM_HASH \
+    --setenv=YOUTUBE_CLIENTID \
+    --setenv=YOUTUBE_CLIENTID_HASH \
+    --setenv=YOUTUBE_SECRET \
+    --setenv=YOUTUBE_SECRET_HASH \
     ${CMD}
 
 if [ -e "${R}/etc/apt/apt.conf.d/90cache" ]; then


### PR DESCRIPTION
There are two issues with the GitHub publish workflow:

- the secrets environment variables are not being passed all the way into the systemd container
- the environment variables in the `sudo` command in the workflow yaml make it difficult to read it

This PR fixes both issues, by using `--setenv` in the `systemd-nspawn` command in `build-enter.sh`, and replacing the `sudo env VARIABLE="$VARIABLE"...` chain with `sudo --preserve-env`.

(My assumptions about GitHub's sudo configuration were incorrect when I initially wrote the workflow. I believed the configuration wouldn't allow `--preserve-env` to be used for `sudo` commands without being configured first in `/etc/sudoers`. This is not true, and the environment is correctly preserved when the `--preserve-env` argument is specified on the command.)